### PR TITLE
Feature better errorresponse

### DIFF
--- a/src/tools/hierarchical-tool-registry.ts
+++ b/src/tools/hierarchical-tool-registry.ts
@@ -1216,8 +1216,26 @@ export class HierarchicalSAPToolRegistry {
             const mightBeSelectError = hasSelectString &&
                 selectRelatedErrors.some(term => errorMessage.toLowerCase().includes(term));
 
+            // Extract HTTP response (Axios-style), but do not interpret it
+            const anyError = error as any;
+            const errorResponse = anyError?.response ?? anyError?.originalError?.response;
+
             let responseText = `ERROR: Failed to execute ${args.operation} operation on ${args.entityName}\n\n`;
             responseText += `Error Details: ${errorMessage}\n\n`;
+
+            // Include HTTP status and raw body if available
+            if (errorResponse) {
+                if (errorResponse.status) {
+                    responseText += `HTTP Status: ${errorResponse.status} ${errorResponse.statusText ?? ''}\n\n`;
+                }
+
+                responseText += `== RAW RESPONSE BODY ==\n`;
+                // Prefer the raw data from the client; fall back to the whole response object
+                const raw = errorResponse.data ?? errorResponse;
+                responseText += `${JSON.stringify(raw, null, 2)}\n\n`;
+            } else {
+                responseText += `No HTTP response body was provided by the client.\n\n`;
+            }
 
             if (mightBeSelectError) {
                 responseText += `⚠️ DETECTED: This error might be related to $select not being fully supported by this SAP API.\n\n`;


### PR DESCRIPTION
In case of an error it was only visible which operation failed an the HTTP return code. The real error was only visible in /IWFND/ERROR_LOG, and the error message the MCP server very vague (something like look up the error in /IWFND/ERROR_LOG). The response is not looking aesthetically nice, but by not cherry picking and dumping the whole response body in our MCP response body as well, allows to understand what the real cause of an error was, which is in my view essential for this MCP server. Not to deep in the code, but I assume this only helps in the hierarchical mode, but it definitively helps there, tested it multiple times.